### PR TITLE
2013 01 chicago page

### DIFF
--- a/pages/2013-01-chicago/index.html
+++ b/pages/2013-01-chicago/index.html
@@ -59,7 +59,7 @@ title: University of Chicago 2013
           <a href="http://software-carpentry.org">
             <img src="../../logos/software-carpentry-with-hammer.svg" style="float: right; height: 60px;">
           </a>
-          <h1>Caltech</h1>
+          <h1>University of Chicago</h1>
         </div>
         <br>
         <div class="row-fluid">
@@ -105,7 +105,7 @@ title: University of Chicago 2013
                 <td style="text-align: right;">Python Flow Control</td>
               </tr>
               <tr>
-                <td>3:00 - 4:00</td>
+                <td>3:00 - 4:30</td>
                 <td style="text-align: right;">Python Functions and Modules</td>
               </tr>
             </tbody>


### PR DESCRIPTION
This adds a page for the january chicago bootcamp. It's an exact replica of the caltech page @jiffyclub built, with custom instructions for the chicago bootcamp. 
