### PR TITLE
_posts: Use Jekyll's _posts to avoid nested URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,3 +4,4 @@ pygments: true
 baseurl: /boot-camps
 swc_main: http://software-carpentry.org
 swc_github: http://swcarpentry.github.com
+permalink: /:year-:month-:day-:title.html

--- a/_includes/bootstrap-header.html
+++ b/_includes/bootstrap-header.html
@@ -4,7 +4,7 @@
     <link href="{{site.swc_main}}/css/bootstrap/bootstrap.css" rel="stylesheet" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="{{site.swc_main}}/css/bootstrap/bootstrap-responsive.css" rel="stylesheet" />
-    <link rel="stylesheet" type="text/css" href="../../css/pygments.css" />
+    <link rel="stylesheet" type="text/css" href="{{page.root}}/css/pygments.css" />
     <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
       <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
     <link href="{{site.swc_main}}/css/bootstrap/bootstrap-responsive.css" rel="stylesheet" />
     <link rel="stylesheet" type="text/css" href="{{site.swc_main}}/css/swc.css" />
     <link rel="stylesheet" type="text/css" href="{{site.swc_main}}/css/swc-bootstrap.css" />
-    <link rel="stylesheet" type="text/css" href="../../css/pygments.css" />
+    <link rel="stylesheet" type="text/css" href="{{page.root}}/css/pygments.css" />
     <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
       <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>

--- a/_posts/1900-01-01-example-page/index.md
+++ b/_posts/1900-01-01-example-page/index.md
@@ -1,4 +1,5 @@
 ---
+root: ..
 layout: base
 title: Example Page
 ---

--- a/_posts/2012-10-23-caltech/index.html
+++ b/_posts/2012-10-23-caltech/index.html
@@ -1,4 +1,5 @@
 ---
+root: ..
 title: Caltech 2012
 ---
 <!DOCTYPE html>

--- a/_posts/2013-01-12-chicago/index.html
+++ b/_posts/2013-01-12-chicago/index.html
@@ -1,4 +1,5 @@
 ---
+root: ..
 title: University of Chicago 2013
 ---
 <!DOCTYPE html>


### PR DESCRIPTION
For example,

  http://swcarpentry.github.com/boot-camps/pages/2012-10-caltech/

will be

  http://swcarpentry.github.com/boot-camps/2012-10-23-caltech/

I've added `root` elements to the YAML front matter to avoid
hard-coding the path from each page to the website root in the
_include blurbs, so that any future restructurings will not require
altering the templates.  The `root` element also allows the templates
to be used with nested websites.  For example, from:

  http://swcarpentry.github.com/boot-camps/2012-10-23-caltech/topic/

I've added days to the URL because Jekyll's _posts format requires
them.  We could disable them in _config.yml with:

  permalink: /:year-:month-:title.html

but then you have to ensure that you never hold more than one workshop
per year-month-title.  Adding a day seems safer, but I would be ok
with the abbreviated form.
