### PR TITLE
.mailmap: Standardize identifiers for Lynne and Matt

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+Lynne Williams <williams.lynne99@gmail.com> <alw@Lynne-Williamss-MacBook.local>
+Lynne Williams <williams.lynne99@gmail.com> <williams.lynne99@gmail.com>
+Matt Davis <jiffyclub@gmail.com> <jiffyclub@gmail.com>


### PR DESCRIPTION
Matt's initial commit and Lynne's earlier commits were made with
non-standard names or email addresses.  I picked whatever seemed most
appropriate for each of them and added .mailmap entries to standardize
shortlog output.

@jiffyclub and @LJWilliams, let me know if you'd like your entries
tweaked.
