### PR TITLE
Adding a rough draft of how IPython notebooks for SQL could work.

### DIFF
--- a/Databases.ipynb
+++ b/Databases.ipynb
@@ -1,0 +1,509 @@
+{
+ "metadata": {
+  "name": "Databases"
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "import sqlite3\n",
+      "\n",
+      "connection = sqlite3.connect('test_database.db')\n",
+      "cursor = connection.cursor()\n",
+      "cursor.execute('DROP TABLE IF EXISTS Experiment;')\n",
+      "cursor.execute('CREATE TABLE IF NOT EXISTS Experiment (LoginID INTEGER, Project text, Hours INTEGER, ExperimentDate text);')\n",
+      "cursor.execute('INSERT INTO Experiment (LoginID, Project, Hours, ExperimentDate) Values (\"mlom\", \"Sprockets\", 15, \"1991-03-03\");')\n",
+      "cursor.execute('INSERT INTO Experiment (LoginID, Project, Hours, ExperimentDate) Values (\"mlom\", \"Widgets\", 2, \"1988-03-03\");')\n",
+      "cursor.execute('INSERT INTO Experiment (LoginID, Project, Hours, ExperimentDate) Values (\"best\", \"Sprockets\", 7, \"1988-03-03\");')\n",
+      "cursor.execute('INSERT INTO Experiment (LoginID, Project, Hours, ExperimentDate) Values (\"best\", \"Widgets\", 13, \"1991-03-03\");')\n",
+      "connection.commit()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 50
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Selecting Data\n",
+      "==============\n",
+      "\n",
+      "As we've seen, a database is a way to store information that is arranged as tables. We will be using a database that has a single table named `Experiment`. This table is a log of all of the work done on experiments in a research lab, broken down by project and scientist. The table has a column for the login id of the scientist, the name of their project, a numeric id for their experiment, how many hours they spent on it, and when it took place. Each row, or record, in this table describes one scientist's work on a certain experiment on a given date.  \n",
+      "\n",
+      "To start, lets write an SQL query that retrieves the `loginID` and the `Project` name from the `Experiment` table. We do that by using the SQL command, `SELECT`. We then list the columns we want to read from the database table. We want the `LoginID`, and `Project` name, so we write those column names, and then we write `FROM`, and the name of the table we want the data from, `Experiment`:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "cursor.execute('SELECT LoginID, Project FROM Experiment;')\n",
+      "cursor.fetchall()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "pyout",
+       "prompt_number": 51,
+       "text": [
+        "[(u'mlom', u'Sprockets'),\n",
+        " (u'mlom', u'Widgets'),\n",
+        " (u'best', u'Sprockets'),\n",
+        " (u'best', u'Widgets')]"
+       ]
+      }
+     ],
+     "prompt_number": 51
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "We put a semi-colon at the end to tell the database this is the end of the command. I've capitalised the words SELECT, and FROM because they are SQL keywords. Capitalisation isn't necessary, but we'll continue this throughout the screencast so that it is clear what is a keyword and what is a table name or field name. When we run the command, it shows us all of the data from the `Experiment` table for the two columns that we asked for: the `LoginID`, and the name of the `Project`. If wanted the `Hours` column, we'd just add that to the list of columns in the `SELECT` clause:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "cursor.execute('SELECT LoginID, Project, Hours FROM Experiment;')\n",
+      "cursor.fetchall()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "pyout",
+       "prompt_number": 52,
+       "text": [
+        "[(u'mlom', u'Sprockets', 15),\n",
+        " (u'mlom', u'Widgets', 2),\n",
+        " (u'best', u'Sprockets', 7),\n",
+        " (u'best', u'Widgets', 13)]"
+       ]
+      }
+     ],
+     "prompt_number": 52
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "So, After the `SELECT` command you listed the fields you want returned. You can place them in any order. We could write:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "cursor.execute('SELECT Project, LoginID FROM Experiment;')\n",
+      "cursor.fetchall()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "pyout",
+       "prompt_number": 53,
+       "text": [
+        "[(u'Sprockets', u'mlom'),\n",
+        " (u'Widgets', u'mlom'),\n",
+        " (u'Sprockets', u'best'),\n",
+        " (u'Widgets', u'best')]"
+       ]
+      }
+     ],
+     "prompt_number": 53
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "And you can repeat field names if you'd like:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "cursor.execute('SELECT Project, LoginID, LoginID, Project FROM Experiment;')\n",
+      "cursor.fetchall()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "pyout",
+       "prompt_number": 54,
+       "text": [
+        "[(u'Sprockets', u'mlom', u'mlom', u'Sprockets'),\n",
+        " (u'Widgets', u'mlom', u'mlom', u'Widgets'),\n",
+        " (u'Sprockets', u'best', u'best', u'Sprockets'),\n",
+        " (u'Widgets', u'best', u'best', u'Widgets')]"
+       ]
+      }
+     ],
+     "prompt_number": 54
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "If you want to pull up all of the columns in a table, you can use the asterisk, or star, after SELECT. The asterisk means \"all of the column names\" \u2014 it is just a shortcut. So, if we run this query:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "cursor.execute('SELECT * FROM Experiment;')\n",
+      "cursor.fetchall()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "pyout",
+       "prompt_number": 55,
+       "text": [
+        "[(u'mlom', u'Sprockets', 15, u'1991-03-03'),\n",
+        " (u'mlom', u'Widgets', 2, u'1988-03-03'),\n",
+        " (u'best', u'Sprockets', 7, u'1988-03-03'),\n",
+        " (u'best', u'Widgets', 13, u'1991-03-03')]"
+       ]
+      }
+     ],
+     "prompt_number": 55
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "we see all of the columns from the Experiment table. If the there are duplicate rows returned by your query, it is possible to remove the duplicates. For example, we can fetch only the Project column from the Experiment table:\n",
+      "\n"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "cursor.execute('SELECT Project FROM Experiment;')\n",
+      "cursor.fetchall()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "pyout",
+       "prompt_number": 56,
+       "text": [
+        "[(u'Sprockets',), (u'Widgets',), (u'Sprockets',), (u'Widgets',)]"
+       ]
+      }
+     ],
+     "prompt_number": 56
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "and if we just wanted to know which different Projects the scientists were working on , we put DISTINCT keyword right after the SELECT keyword,"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "cursor.execute('SELECT DISTINCT Project FROM Experiment;')\n",
+      "cursor.fetchall()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "pyout",
+       "prompt_number": 57,
+       "text": [
+        "[(u'Sprockets',), (u'Widgets',)]"
+       ]
+      }
+     ],
+     "prompt_number": 57
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "This lists all of the projects, but only once.If select more than one column name:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "cursor.execute('SELECT DISTINCT Project, LoginID FROM Experiment;')\n",
+      "cursor.fetchall()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "pyout",
+       "prompt_number": 58,
+       "text": [
+        "[(u'Sprockets', u'mlom'),\n",
+        " (u'Widgets', u'mlom'),\n",
+        " (u'Sprockets', u'best'),\n",
+        " (u'Widgets', u'best')]"
+       ]
+      }
+     ],
+     "prompt_number": 58
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "then only the distinct pairs of projects and login IDs are returned. Suppose that 10% of the time spent on each experiment was prep. work which needs to be accounted for separately. In our SELECT statement we can add expressions that do computations on each row. So, to calculate 10% of the time spent on each experiment, we can add an expression to the list of columns in the SELECT field (in this case we'll leave the * there to select all of the columns), but we'll add the expression Hours * .1"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "cursor.execute('SELECT *, Hours * .1 FROM Experiment;')\n",
+      "cursor.fetchall()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "pyout",
+       "prompt_number": 59,
+       "text": [
+        "[(u'mlom', u'Sprockets', 15, u'1991-03-03', 1.5),\n",
+        " (u'mlom', u'Widgets', 2, u'1988-03-03', 0.2),\n",
+        " (u'best', u'Sprockets', 7, u'1988-03-03', 0.7000000000000001),\n",
+        " (u'best', u'Widgets', 13, u'1991-03-03', 1.3)]"
+       ]
+      }
+     ],
+     "prompt_number": 59
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "When we run the query, the expression Hours * .1 is evaluated for each row and appended to the output.When appending expressions in the SELECT clause, you can use any of the fields, all of the arthimetic operators can be used here, as well as a certain built-in functions. For instance, We could round these values to the first decimal place by using the ROUND function:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "cursor.execute('SELECT *, ROUND(Hours * .1, 1) FROM Experiment;')\n",
+      "cursor.fetchall()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "pyout",
+       "prompt_number": 60,
+       "text": [
+        "[(u'mlom', u'Sprockets', 15, u'1991-03-03', 1.5),\n",
+        " (u'mlom', u'Widgets', 2, u'1988-03-03', 0.2),\n",
+        " (u'best', u'Sprockets', 7, u'1988-03-03', 0.7),\n",
+        " (u'best', u'Widgets', 13, u'1991-03-03', 1.3)]"
+       ]
+      }
+     ],
+     "prompt_number": 60
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "In this screencast we've introduced the very basics of interacting with and retrieving data from database. We've seen that you can select columns from a table to retreive, use the DISTINCT keyword to only return unique rows, as well as append calculated columns to output."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Filtering Results\n",
+      "================="
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "One of the most powerful features of a database is the ability to filter through your data to find the records that match certain criteria. Let's say we wanted to see all of the Experiments before the year 1990. To do this we'd write a SELECT query with all of the columns from the Experiments table, SELECT * FROM Experiment\n",
+      "and we use the WHERE command to specify our filter conditions ... WHERE We put the expression, ExperimentDate < '1990-01-01'"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "cursor.execute('SELECT * FROM Experiment WHERE ExperimentDate < \"1990-01-01\";')\n",
+      "cursor.fetchall()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "pyout",
+       "prompt_number": 61,
+       "text": [
+        "[(u'mlom', u'Widgets', 2, u'1988-03-03'),\n",
+        " (u'best', u'Sprockets', 7, u'1988-03-03')]"
+       ]
+      }
+     ],
+     "prompt_number": 61
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "This specifies that we want only experiment info with an experiment date before January 1st, 1990. You can think about how this query works as the database inspecting each row from the Experiments table, and checking it against the condition in the WHERE clause. If the condition holds true, then that row is included in the results, otherwise it is filtered out. We can use other comparison operators in our filtering conditions. For example, we could ask for all of the Experiments in table that took 3 or more hours. To do this we change the WHERE condition to be Hours >= 3\n"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "cursor.execute('SELECT * FROM Experiment WHERE Hours >= 3;')\n",
+      "cursor.fetchall()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "pyout",
+       "prompt_number": 62,
+       "text": [
+        "[(u'mlom', u'Sprockets', 15, u'1991-03-03'),\n",
+        " (u'best', u'Sprockets', 7, u'1988-03-03'),\n",
+        " (u'best', u'Widgets', 13, u'1991-03-03')]"
+       ]
+      }
+     ],
+     "prompt_number": 62
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "We can use most of the familiar comparision operators: equal to, not equal to, greater than, less than, and so on. We can make our WHERE conditions even more sophisticated by using logical operators like AND and OR to combine conditions.For instance, if we want to find all of the experiments run by mlom that took more than three hours, we can modify our query. It already filters for experiments that take more than 3 hours. We can add AND and then the other condition that needs to be met, that the loginID is mlom:\n"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "cursor.execute('SELECT * FROM Experiment WHERE Hours >= 3 AND LoginID = \"mlom\";')\n",
+      "cursor.fetchall()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "pyout",
+       "prompt_number": 63,
+       "text": [
+        "[(u'mlom', u'Sprockets', 15, u'1991-03-03')]"
+       ]
+      }
+     ],
+     "prompt_number": 63
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "When using an AND operator, each record returned now must satisfy two conditions: in this case, the Hours spent has to be greater than 3, and the loginID must be mlom. If we wanted experiments either by mlom or by best, we would write"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "cursor.execute('SELECT * FROM Experiment WHERE Hours >= 3 AND (LoginID = \"mlom\" OR LoginID = \"best\");')\n",
+      "cursor.fetchall()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "pyout",
+       "prompt_number": 64,
+       "text": [
+        "[(u'mlom', u'Sprockets', 15, u'1991-03-03'),\n",
+        " (u'best', u'Sprockets', 7, u'1988-03-03'),\n",
+        " (u'best', u'Widgets', 13, u'1991-03-03')]"
+       ]
+      }
+     ],
+     "prompt_number": 64
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "The parentheses ensure that the OR-clause is evaluated first, so it is true whether the loginID is mlom or best, and the entire WHERE condition is true if the OR-clause is true AND the hours spent are greater than 3. Another way to write this OR-clause is to use the IN operator. With this operator, we can write a condition that is true if a field\u2014the loginID in this case\u2014contains anything from a list of values:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "cursor.execute('SELECT * FROM Experiment WHERE Hours >= 3 AND LoginID IN (\"mlom\", \"best\");')\n",
+      "cursor.fetchall()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "pyout",
+       "prompt_number": 65,
+       "text": [
+        "[(u'mlom', u'Sprockets', 15, u'1991-03-03'),\n",
+        " (u'best', u'Sprockets', 7, u'1988-03-03'),\n",
+        " (u'best', u'Widgets', 13, u'1991-03-03')]"
+       ]
+      }
+     ],
+     "prompt_number": 65
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "This is exactly the same as writing out the OR clause, but it's shorter to write, and easier to read."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 49
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}


### PR DESCRIPTION
As I mentioned on the [tutors] listserv I made a rough draft of an IPython notebook based (verbatim) on the first two SWC SQL lessons. The notebook uses the python `SQLite3` module to execute the SQL commands. `SQLite3` uses raw SQL commands so in that sense the lesson material is the same. 

Some people have expressed concern that combining Python with SQL will cause more confusion than it's worth, though other people really like using the IPython notebook. I've taught SQL this way before but I have no way of measuring how much traction I had.

Comments are welcome. If there is interest I could add the remaining lessons.
