### PR TITLE
Replacing double quoted strings with single quotes in SQL Cheat Sheet

### DIFF
--- a/sql/cheat-sheet.md
+++ b/sql/cheat-sheet.md
@@ -26,11 +26,11 @@ Filtering
 
 Select only the data meeting certain criteria:
 
-    SELECT * FROM table_name WHERE column_name = "Hello World";
+    SELECT * FROM table_name WHERE column_name = 'Hello World';
 
 Combine conditions:
 
-    SELECT * FROM table_name WHERE (column_name_1 >= 1000) AND (column_name_2 = "A" OR column_name_2 = "B");
+    SELECT * FROM table_name WHERE (column_name_1 >= 1000) AND (column_name_2 = 'A' OR column_name_2 = 'B');
 
 
 Sorting


### PR DESCRIPTION
As pointed out by David Martin the single quotes only work in some implementations
of SQL (MySQL and SQLite). This change makes the Cheat Sheet work in all
implementations.
