### PR TITLE
Adding a simple Python-as-calculator exercise

### DIFF
--- a/python/python-as-calculator/A Math Trick.ipynb
+++ b/python/python-as-calculator/A Math Trick.ipynb
@@ -1,0 +1,121 @@
+{
+ "metadata": {
+  "name": "A Math Trick"
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "heading",
+     "level": 1,
+     "metadata": {},
+     "source": [
+      "A Math Trick"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Adapted from [http://easycalculation.com/funny/tricks/tricks3.php](http://easycalculation.com/funny/tricks/tricks3.php).\n",
+      "\n",
+      "Choose any three digit number and multiply it by 80."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Add 1 to the result."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Multiply the result by 250."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Choose a four digit a number ending in 0. Add it twice to the result above."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Subtract 250 from the result."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Divide the above by 2."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "The result should be a concatenation of the numbers you chose!"
+     ]
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}

--- a/python/python-as-calculator/README.md
+++ b/python/python-as-calculator/README.md
@@ -1,0 +1,7 @@
+These notebooks involve using Python for simple math exercises.
+
+* A Math Trick
+  * A series of simple, integer arithmetic steps which result in a silly
+    math trick. Intended as a first step into Python and the notebook so
+    students become familiar with pressing `shift-Enter` and entering code
+    into cells.


### PR DESCRIPTION
This just adds a simple math exercise that should be easy for students and get them used to work in the notebook. [View here.](http://nbviewer.ipython.org/urls/raw.github.com/jiffyclub/boot-camps/python-calculator/python/python-as-calculator/A%20Math%20Trick.ipynb) (nbviewer doesn't seem to show the empty code cells that should appear between the lines of text.)
