### PR TITLE
shell/Readme.md: Replace `which` with `command -v`

### DIFF
--- a/shell/Readme.md
+++ b/shell/Readme.md
@@ -400,15 +400,15 @@ is very useful.
 
 Commands like `ls`, `rm`, `echo`, and `cd` are just ordinary programs
 on the computer. A program is just a file that you can *execute*. The
-program `which` tells you the location of a particular program. For
+program `command` tells you the location of a particular program. For
 example:
 
-    which ls
+    command -v ls
 
 Will return "/bin/ls". Thus, we can see that `ls` is a program that
 sits inside of the `/bin` directory. Now enter:
 
-    which find
+    command -v find
 
 You will see that `find` is a program that sits inside of the
 `/usr/bin` directory.


### PR DESCRIPTION
I just learned (via the Git list [1](http://article.gmane.org/gmane.comp.version-control.git/216007)) that `which` is not part of POSIX.  The
POSIX 2008 equivalent is `command -v` [2](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html).  We can make the shell introduction
more portable by sticking to the POSIX utilities [3](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap04.html#tag_20).

I can't think of a system that _hasn't_ had a `which` [4,5], but there's bound
to be one sooner or later ;).

[4]: Gentoo uses the GNU implementation developed by Carlo Wood [6](http://savannah.gnu.org/projects/which):
    This implementation seems to have used a which 1.0 by Paul Vixie
    as a starting point [7](http://cvs.savannah.gnu.org/viewvc/which/README.in?revision=1.1&root=which&view=markup) in 1999, but I've been unable to track
    down any history for Paul's version.
[5]: Even my university's archaic SunOS 5.10 server has a csh
    implementation of `which`, (c) 1997, by Sun Microsystems, Inc.

```
http://carlo17.home.xs4all.nl/which/
```
