### PR TITLE
Work around a nested list formatting bug in the default markdown parser

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,4 +5,4 @@ baseurl: /boot-camps
 swc_main: http://software-carpentry.org
 swc_github: http://swcarpentry.github.com
 permalink: /:year-:month-:day-:title.html
-markdown: rdiscount
+markdown: redcarpet


### PR DESCRIPTION
This isolates the single fix from pull request #97.
See https://github.com/bhollis/maruku/issues/64 for original bug.
Using the rdiscount parser instead worked for the Oxford DTC boot camp.
