### PR TITLE
2013-06-24-wise: Cleanup HTML markup

### DIFF
--- a/_posts/2013-06-24-wise/index.html
+++ b/_posts/2013-06-24-wise/index.html
@@ -6,24 +6,7 @@ title: Women in Science and Engineering 2013
 <html lang="en">
   <head>
     {% include bootstrap-header.html %}
-    <style>
-      body {
-        padding-top: 60px; /* 60px to make the container go all the way to the bottom of the topbar */
-      }
-      .welcome {
-        font-size: 120%;
-      }
-      h4 {
-        text-decoration: underline;
-      }
-      .brand {
-        background-color: transparent;
-        background-image: url("{{page.root}}/logos/swc-logo.svg");
-        background-repeat: no-repeat;
-        background-size: auto 36px;
-        background-position: center;
-      }
-    </style>
+    <link rel="stylesheet" type="text/css" media="screen" href="style.css" />
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>

--- a/_posts/2013-06-24-wise/room1.html
+++ b/_posts/2013-06-24-wise/room1.html
@@ -6,18 +6,7 @@ title: Women in Science and Engineering 2013
 <html lang="en">
   <head>
     {% include bootstrap-header.html %}
-    <style>
-      body {
-        padding-top: 60px; /* 60px to make the container go all the way to the bottom of the topbar */
-      }
-      .brand {
-        background-color: transparent;
-        background-image: url("{{page.root}}/logos/swc-logo.svg");
-        background-repeat: no-repeat;
-        background-size: auto 36px;
-        background-position: center;
-      }
-    </style>
+    <link rel="stylesheet" type="text/css" media="screen" href="style.css" />
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>

--- a/_posts/2013-06-24-wise/room2.html
+++ b/_posts/2013-06-24-wise/room2.html
@@ -6,18 +6,7 @@ title: Women in Science and Engineering 2013
 <html lang="en">
   <head>
     {% include bootstrap-header.html %}
-    <style>
-      body {
-        padding-top: 60px; /* 60px to make the container go all the way to the bottom of the topbar */
-      }
-      .brand {
-        background-color: transparent;
-        background-image: url("{{page.root}}/logos/swc-logo.svg");
-        background-repeat: no-repeat;
-        background-size: auto 36px;
-        background-position: center;
-      }
-    </style>
+    <link rel="stylesheet" type="text/css" media="screen" href="style.css" />
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>

--- a/_posts/2013-06-24-wise/room3.html
+++ b/_posts/2013-06-24-wise/room3.html
@@ -6,18 +6,7 @@ title: Women in Science and Engineering 2013
 <html lang="en">
   <head>
     {% include bootstrap-header.html %}
-    <style>
-      body {
-        padding-top: 60px; /* 60px to make the container go all the way to the bottom of the topbar */
-      }
-      .brand {
-        background-color: transparent;
-        background-image: url("{{page.root}}/logos/swc-logo.svg");
-        background-repeat: no-repeat;
-        background-size: auto 36px;
-        background-position: center;
-      }
-    </style>
+    <link rel="stylesheet" type="text/css" media="screen" href="style.css" />
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>

--- a/_posts/2013-06-24-wise/style.css
+++ b/_posts/2013-06-24-wise/style.css
@@ -1,0 +1,19 @@
+body {
+  padding-top: 60px; /* 60px to make the container go all the way to the bottom of the topbar */
+}
+
+.welcome {
+  font-size: 120%;
+}
+
+h4 {
+  text-decoration: underline;
+}
+
+.brand {
+  background-color: transparent;
+  background-image: url("{{page.root}}/logos/swc-logo.svg");
+  background-repeat: no-repeat;
+  background-size: auto 36px;
+  background-position: center;
+}

--- a/_posts/2013-06-24-wise/test_install.html
+++ b/_posts/2013-06-24-wise/test_install.html
@@ -6,21 +6,7 @@ title: Women in Science and Engineering 2013
 <html lang="en">
   <head>
     {% include bootstrap-header.html %}
-    <style>
-      body {
-        padding-top: 60px; /* 60px to make the container go all the way to the bottom of the topbar */
-      }
-      .welcome {
-        font-size: 120%;
-      }
-      .brand {
-        background-color: transparent;
-        background-image: url("{{page.root}}/logos/swc-logo.svg");
-        background-repeat: no-repeat;
-        background-size: auto 36px;
-        background-position: center;
-      }
-    </style>
+    <link rel="stylesheet" type="text/css" media="screen" href="style.css" />
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>


### PR DESCRIPTION
The exising WiSE pages have a number of markup issues, which I've
fixed in this PR.  For example, compare:
- http://wking.github.io/swc-boot-camps/2013-06-24-wise/test_install.html
- http://swcarpentry.github.io/boot-camps/2013-06-24-wise/test_install.html

The pages now pass the W3C validator (http://validator.w3.org/) with
the only error being the lack of a character encoding declaration.
Since that should be fixed at the layout level, I've left it
unchanged.

There is a lot of other boilerplate in here that should be dealt with
at the layout level, but this cleans the site up enough for tomorrow,
and we can work out a better system for moving forward at a more
relaxed pace ;).
